### PR TITLE
static: adapt to be paas-deployable

### DIFF
--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -6,7 +6,5 @@ COPY responses/ /srv/responses
 COPY mock-third-party/ /srv/mock-third-party
 
 RUN rm -f /etc/nginx/conf.d/default.conf && \
-  sed -E -i 's|^http \{|\0 map $host $mock_ckan_responses_root { default /srv/responses; } map $host $mock_third_party_root { default /srv/mock-third-party; } include /etc/nginx/vars.conf;|' /etc/nginx/nginx.conf
-
-EXPOSE 1088
-
+  sed -E -i 's|^http \{|\0 map $host $mock_ckan_responses_root { default /srv/responses; } map $host $mock_third_party_root { default /srv/mock-third-party; } include /etc/nginx/vars.conf;|' /etc/nginx/nginx.conf && \
+  sed -E -i 's|\b11088\b|80|' /etc/nginx/conf.d/mock-ckan.conf

--- a/static/README.md
+++ b/static/README.md
@@ -25,4 +25,13 @@ The server can be run in two ways:
  - For easy development a user with a working Nix installation should just be able
    to run `nix-shell . --pure --run "nginx"` to start an nginx daemon running
    locally.
- - A `Dockerfile` is also provided for more permanent deployments.
+ - A `Dockerfile` is also provided. This can be used to build an image suitable for
+   use in cloudfoundry (see the included `manifest.yml`) or used to run the server
+   locally. The resulting docker image will listen on port 80 by default and can be
+   started locally with a command such as `docker run -p 127.0.0.1:11088:80 <docker-image>`,
+   which would expose the server on local port 11088.
+
+Connecting to a locally-running mock harvest source from a dockerized ckan instance will
+require use of the `host.docker.internal` hostname, which should also be reflected in the
+`$mock_absolute_root_url` setting to allow self-references to work. Note this still won't
+work perfectly until full integration with the docker-compose environment is done.

--- a/static/default.nix
+++ b/static/default.nix
@@ -21,6 +21,7 @@ in (with args; {
           thirdPartyDir = (toString (./.)) + "/mock-third-party";
           varsConf = (toString (./.)) + "/vars.conf";
         })
+        pkgs.cloudfoundry-cli
       ];
 
       # if we don't have this, we get unicode troubles in a --pure nix-shell

--- a/static/manifest.yml
+++ b/static/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: ckan-static-mock-harvest-source
+  memory: 192M
+  instances: 1
+  health-check-type: http
+  health-check-http-endpoint: /status
+  docker:
+    image: risicle/ckan-static-mock-harvest-source:0.0.4

--- a/static/sites/mock-ckan.conf
+++ b/static/sites/mock-ckan.conf
@@ -44,4 +44,10 @@ server {
 
         try_files $uri$is_args$args =404;
     }
+
+    location = /status {
+        return 200 'Seems to be fine';
+        types { }
+        default_type "text/plain";
+    }
 }

--- a/static/sites/mock-ckan.conf
+++ b/static/sites/mock-ckan.conf
@@ -50,4 +50,10 @@ server {
         types { }
         default_type "text/plain";
     }
+
+    location = / {
+        return 200 'This is a mock CKAN harvest source. Set this URL as a harvest source for a CKAN instance to have it populated with some dummy data.';
+        types { }
+        default_type "text/plain";
+    }
 }

--- a/static/sites/mock-ckan.conf
+++ b/static/sites/mock-ckan.conf
@@ -6,7 +6,7 @@ map $uri $apiless_uri {
 }
 
 server {
-    listen       1088;
+    listen       11088;
     server_name  _;
     types { }
 

--- a/static/sites/mock-ckan.conf
+++ b/static/sites/mock-ckan.conf
@@ -8,7 +8,6 @@ map $uri $apiless_uri {
 server {
     listen       11088;
     server_name  _;
-    types { }
 
     ssi on;
     ssi_types *;
@@ -18,18 +17,21 @@ server {
 
     location /api {
         root $mock_ckan_responses_root/json;
+        types { }
         default_type "application/json";
         try_files $apiless_uri$is_args$args @html;
     }
 
     location @html {
         root $mock_ckan_responses_root/html;
+        types { }
         default_type "text/html";
         try_files $apiless_uri$is_args$args @xml;
     }
 
     location @xml {
         root $mock_ckan_responses_root/xml;
+        types { }
         default_type "text/xml";
         try_files $apiless_uri$is_args$args =404;
     }

--- a/static/vars.conf
+++ b/static/vars.conf
@@ -1,3 +1,3 @@
 # to set these variables we abuse `map` because they are injected in a context
 # that `set` is not allowed in
-map $host $mock_absolute_root_url { default "http://127.0.0.1:1088/"; }
+map $host $mock_absolute_root_url { default "http://127.0.0.1:11088/"; }


### PR DESCRIPTION
https://trello.com/b/VaDqx6Df

This required some tinkering to get it to work properly. I've been i'm still trying to avoid requiring a run-time pre-processing script for conf files because that gets in the way of having a "live" development mode, and nginx's support for reading settings from variables is atrocious. So there are a few weird twisty uses of nginx `map`s etc to get things to behave as I want. The oddest of these is substitution of port numbers at docker build time. This is necessary because I want the configuration to be immediately runnable from userspace, which therefore means it needs to bind to a port > 1024. However the `nginx` docker image has declared itself to `EXPOSE` port 80, which is something you can't undo in derivative `Dockerfile`s. And paas will attach its route to the first exposed port it sees. So this means that in the docker image we really do have to use port 80.
