### PR TITLE
static: package_search response: add PII fields to package

### DIFF
--- a/static/responses/json/3/action/package_search?sort=id+asc&start=0&rows=100
+++ b/static/responses/json/3/action/package_search?sort=id+asc&start=0&rows=100
@@ -147,6 +147,10 @@
         "url": "<!--#echo var="mock_absolute_root_url" -->mock-third-party/example-dataset-1/about",
         "notes": "This is an example CKAN dataset consisting of a number of active resources.",
         "owner_org": "9f3af52d-7a2e-4962-95c7-15a23b6e0b82",
+        "author": "Nobody",
+        "author_email": "nobody@example.com",
+        "maintainer": "Nobody",
+        "maintainer_email": "nobody@example.com",
         "extras": [
           {
             "key": "taxonomy_url",


### PR DESCRIPTION
https://trello.com/c/mZzEEwHo 

This should give us some further assurance that these fields don't get (visibly) propagated to our own CKAN instances.