### PR TITLE
Dockerfile: change port number hack to add 80 as an additional port

### DIFF
--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -7,4 +7,4 @@ COPY mock-third-party/ /srv/mock-third-party
 
 RUN rm -f /etc/nginx/conf.d/default.conf && \
   sed -E -i 's|^http \{|\0 map $host $mock_ckan_responses_root { default /srv/responses; } map $host $mock_third_party_root { default /srv/mock-third-party; } include /etc/nginx/vars.conf;|' /etc/nginx/nginx.conf && \
-  sed -E -i 's|\b11088\b|80|' /etc/nginx/conf.d/mock-ckan.conf
+  sed -E -i 's|^server \{|\0 listen 80;|' /etc/nginx/conf.d/mock-ckan.conf

--- a/static/README.md
+++ b/static/README.md
@@ -27,11 +27,12 @@ The server can be run in two ways:
    locally.
  - A `Dockerfile` is also provided. This can be used to build an image suitable for
    use in cloudfoundry (see the included `manifest.yml`) or used to run the server
-   locally. The resulting docker image will listen on port 80 by default and can be
-   started locally with a command such as `docker run -p 127.0.0.1:11088:80 <docker-image>`,
+   locally. The resulting docker image will listen on both ports 80 and 11088 by default
+   and can be started locally with a command such as `docker run -p 127.0.0.1:11088:80 <docker-image>`,
    which would expose the server on local port 11088.
 
-Connecting to a locally-running mock harvest source from a dockerized ckan instance will
-require use of the `host.docker.internal` hostname, which should also be reflected in the
-`$mock_absolute_root_url` setting to allow self-references to work. Note this still won't
-work perfectly until full integration with the docker-compose environment is done.
+Connecting to a locally-running mock harvest source from a dockerized ckan instance (outside
+the docker-compose environment) will require use of the `host.docker.internal` hostname, which
+should also be reflected in the `$mock_absolute_root_url` setting to allow self-references
+to work.
+


### PR DESCRIPTION
https://trello.com/c/DidXW0Xv

Instead of overwriting the port number. This means that images still listen on port 11088, which is useful for use in docker compose because we don't want to have to bind to external port 80 on a dev machine for browser access.

Config file mangling should also be more robust.
