### PR TITLE
static paas manifest: switch docker image to one from govuk repository

### DIFF
--- a/static/manifest.yml
+++ b/static/manifest.yml
@@ -6,4 +6,4 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /status
   docker:
-    image: risicle/ckan-static-mock-harvest-source:0.0.4
+    image: govuk/ckan-static-mock-harvest-source:0.0.4


### PR DESCRIPTION
It's the same image, though.

I've already pushed this to paas and it works fine.