### PR TITLE
Add manifest dynamic

### DIFF
--- a/dynamic/main.py
+++ b/dynamic/main.py
@@ -77,4 +77,4 @@ def catch_all(path):
 
 
 if __name__ == "__main__":
-    app.run(debug=os.getenv("DEBUG", False), host='0.0.0.0', port=int(os.getenv("PORT", 8001)))
+    app.run(debug='DEBUG' in os.environ, host='0.0.0.0', port=int(os.getenv("PORT", 8001)))

--- a/dynamic/main.py
+++ b/dynamic/main.py
@@ -1,3 +1,4 @@
+import os
 import time
 from flask import request, Flask, Response
 
@@ -10,6 +11,9 @@ NUM_DIGITS=3
 @app.route('/', defaults={'path': '0'})
 @app.route('/<path:path>')
 def catch_all(path):
+    if path == 'healthcheck':
+        return 'OK', 200
+
     if not path.endswith('.tmp.xml') and not path.endswith('/'):
         return '''
             URL needs to end with /<br><br>
@@ -73,4 +77,4 @@ def catch_all(path):
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host='0.0.0.0', port=8001)
+    app.run(debug=os.getenv("DEBUG", False), host='0.0.0.0', port=int(os.getenv("PORT", 8001)))

--- a/dynamic/manifest.yml
+++ b/dynamic/manifest.yml
@@ -1,0 +1,9 @@
+---
+buildpack: python_buildpack
+command: python main.py
+applications:
+  - name: ckan-dynamic-mock-harvest-source
+    memory: 128M
+    instances: 1
+    health-check-type: http
+    health-check-http-endpoint: /healthcheck

--- a/dynamic/test.tmp.xml
+++ b/dynamic/test.tmp.xml
@@ -282,7 +282,7 @@
             <gmd:descriptiveKeywords>
                 <gmd:MD_Keywords>
                     <gmd:keyword>
-                        <gco:CharacterString>Soil</gco:CharacterString>
+                        <gco:CharacterString>{{url-index}}{{end-guid}}Soil?*[</gco:CharacterString>
                     </gmd:keyword>
                     <gmd:type>
                         <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
@@ -312,7 +312,7 @@
                         <gmx:Anchor xlink:href="http://onto.nerc.ac.uk/CEHMD/topic/17">Soil</gmx:Anchor>
                     </gmd:keyword>
                     <gmd:keyword>
-                        <gco:CharacterString>Some Habitat</gco:CharacterString>
+                        <gco:CharacterString>Some Habitat/test***??[]</gco:CharacterString>
                     </gmd:keyword>
                     <gmd:keyword>
                         <gco:CharacterString>Soils</gco:CharacterString>


### PR DESCRIPTION
## What

Enable the dynamic mock harvest source to be deployed onto the PaaS by adding a manifest.yml and updating the code to pick up the port.

Also update the dynamic test data template to make the tags unique.